### PR TITLE
fix: base64 encode audio in fallback path

### DIFF
--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import os
 import argparse
@@ -35,7 +36,8 @@ def upload_audio(wav, sample_rate, key):
             }
         )
     # Base64 encode
-    return wav_io.decode('UTF-8')
+    wav_io.seek(0)
+    return base64.b64encode(wav_io.read()).decode('UTF-8')
 
 
 def run(job):


### PR DESCRIPTION
## Summary
The base64 fallback path in `upload_audio()` (when no S3 bucket is configured) calls `wav_io.decode('UTF-8')` on a `BytesIO` object containing raw WAV binary data. This fails silently, causing RunPod jobs to complete with `status: COMPLETED` but no `output`.

## Fix
- `import base64`
- `wav_io.seek(0)` to reset cursor after `scipy.io.wavfile.write()`
- `base64.b64encode(wav_io.read()).decode('UTF-8')` for proper encoding

## Testing
Confirmed the bug via RunPod serverless endpoint — jobs execute in ~1s but return empty output. With this fix, the base64-encoded WAV audio is properly returned in the response.